### PR TITLE
use destructive style for logout, make it easier to dismiss screen

### DIFF
--- a/NightscoutServiceKitUI/Views/ServiceStatusView.swift
+++ b/NightscoutServiceKitUI/Views/ServiceStatusView.swift
@@ -59,14 +59,21 @@ struct ServiceStatusView: View, HorizontalSizeClassOverride {
             Button(action: {
                 viewModel.didLogout?()
             } ) {
-                Text("Logout").padding(.top, 20)
-            }
+                Text("Logout")
+            }.actionButtonStyle(.destructive)
         }
         .padding([.leading, .trailing])
         .navigationBarTitle("")
+        .navigationBarItems(leading: backButton)
         .navigationBarItems(trailing: dismissButton)
     }
     
+    private var backButton: some View {
+        Button(action: dismiss) {
+            Text("Back").bold()
+        }
+    }
+
     private var dismissButton: some View {
         Button(action: dismiss) {
             Text("Done").bold()


### PR DESCRIPTION
I was helping a friend who could not figure out how she was removing the Nightscout URL from her Loop app.

Finally figured it out. She was tapping the logout (blue and at bottom of the screen) instead of tapping the Done button.

In this PR, the logout button uses destructive format and there is an added Back button. See graphic below

* The original screen is shown on the left
* The new features are highlighted by green rectangles on the right


![use-destructive-style-logout](https://github.com/LoopKit/NightscoutService/assets/19607791/9d80e22e-18d5-4b2b-be09-378807004226)

