### PR TITLE
Use random seconds component on remote carb entries.

### DIFF
--- a/NightscoutServiceKit/RemoteCommands/V1/Notifications/RemoteNotification.swift
+++ b/NightscoutServiceKit/RemoteCommands/V1/Notifications/RemoteNotification.swift
@@ -68,7 +68,8 @@ extension Dictionary<String, AnyObject> {
         if BolusRemoteNotification.includedInNotification(self) {
             return try BolusRemoteNotification(dictionary: self)
         } else if CarbRemoteNotification.includedInNotification(self) {
-            return try CarbRemoteNotification(dictionary: self)
+            let carbRemoteNotification = try CarbRemoteNotification(dictionary: self)
+            return carbRemoteNotification.adjustedCarbEntryWithRandomSecondsComponent()
         }  else if OverrideRemoteNotification.includedInNotification(self) {
             return try OverrideRemoteNotification(dictionary: self)
         } else if OverrideCancelRemoteNotification.includedInNotification(self) {


### PR DESCRIPTION
A user can add a remote carb entry from Nightscout. The input box allows a start date/time to be selected. The "start-time" seconds component is always "00". If a user inputs 2 entries for the same time, this can be a problem. Nightscout expects treatments to have unique "created-date"s (which I believe is derived from "start-time" in the carb entry case). The result is the 2nd remote carb entry will not be visible in Nightscout or Caregiver. The fix here on the Loop side is to add a random seconds component to each incoming remote carb entry which should reduce the chance of collisions (1/60)

There is more information in the attached Caregiver case, including some information from Ben West LoopKit/LoopCaregiver#33