### PR TITLE
Swedish translations

### DIFF
--- a/NightscoutServiceKit/sv.lproj/Localizable.strings
+++ b/NightscoutServiceKit/sv.lproj/Localizable.strings
@@ -1,14 +1,40 @@
+/* The remote action name for Bolus Entry */
+"Bolus Entry" = "Bolusinmatning";
+
+/* The remote action name for Cancel Override */
+"Cancel Override" = "Avbryt Override";
+
+/* The remote action name for Carb Entry */
+"Carb Entry" = "Kolhydratinmatning";
+
 /* Name of custom override */
 "Custom Override" = "Anpassad Override";
 
+/* Remote command error description: expired. */
+"Expired" = "Utgången";
+
+/* The remote action abbreviation for gram units */
+"g" = "g";
+
+/* Remote command error description: Missing OTP. */
+"Missing OTP" = "Saknar engångskod";
+
 /* The title of the Nightscout service */
 "Nightscout" = "Nightscout";
+
+/* The remote action name for Override */
+"Override" = "Override";
 
 /* Name of pre-meal workout override
    Name uploaded to Nightscout for Pre-Meal override */
 "Pre-Meal" = "Före måltid";
 
+/* The remote action abbreviation for bolus units */
+"U" = "E";
+
+/* The prefix for the remote unhandled notification error. (1: notification payload) */
+"Unhandled Notification: %1$@" = "Ohanterad avisering: %1$@";
+
 /* Name of legacy workout override
    Name uploaded to Nightscout for legacy workout override */
 "Workout" = "Träning";
-

--- a/NightscoutServiceKitUI/Views/OTPSelectionView.swift
+++ b/NightscoutServiceKitUI/Views/OTPSelectionView.swift
@@ -32,8 +32,8 @@ struct OTPSelectionView: View {
         }, label: {
             Image(systemName: "arrow.clockwise").imageScale(.large)
         }).alert(isPresented: $showingAlert) {
-            Alert(title: Text("Reset Secret Key"),
-                  message: Text("Are you sure you want to reset the secret key?"),
+            Alert(title: Text(LocalizedString("Reset Secret Key", comment: "Dialog title to reset secret key")),
+                  message: Text(LocalizedString("Are you sure you want to reset the secret key?", comment: "Dialog text before resetting secret key")),
                   primaryButton: .default(Text("OK"), action: {
                     otpViewModel.resetSecretKey()
                   }),

--- a/NightscoutServiceKitUI/Views/ServiceStatusView.swift
+++ b/NightscoutServiceKitUI/Views/ServiceStatusView.swift
@@ -18,7 +18,7 @@ struct ServiceStatusView: View, HorizontalSizeClassOverride {
     @State private var selectedItem: String?
     var body: some View {
         VStack {
-            Text("Nightscout")
+            Text(LocalizedString("Nightscout", comment: "Title of service status view"))
                 .font(.largeTitle)
                 .fontWeight(.semibold)
             Image(frameworkImage: "nightscout", decorative: true)
@@ -29,14 +29,14 @@ struct ServiceStatusView: View, HorizontalSizeClassOverride {
 
             VStack(spacing: 0) {
                 HStack {
-                    Text("URL")
+                    Text(LocalizedString("URL", comment: "URL row header in service status view"))
                     Spacer()
                     Text(viewModel.urlString)
                 }
                 .padding()
                 Divider()
                 HStack {
-                    Text("Status")
+                    Text(LocalizedString("Status", comment: "Status row header in service status view"))
                     Spacer()
                     Text(String(describing: viewModel.status))
                 }
@@ -44,7 +44,7 @@ struct ServiceStatusView: View, HorizontalSizeClassOverride {
                 Divider()
                 NavigationLink(destination: OTPSelectionView(otpViewModel: otpViewModel), tag: "otp-view", selection: $selectedItem) {
                     HStack {
-                        Text("One-Time Password")
+                        Text(LocalizedString("One-Time Password", comment: "One-Time Password row header in service status view"))
                         Spacer()
                         Text(otpViewModel.otpCode)
                         Image(systemName: "chevron.right")
@@ -59,7 +59,7 @@ struct ServiceStatusView: View, HorizontalSizeClassOverride {
             Button(action: {
                 viewModel.didLogout?()
             } ) {
-                Text("Logout").padding(.top, 20)
+                Text(LocalizedString("Logout", comment: "Logout button in service status view")).padding(.top, 20)
             }
         }
         .padding([.leading, .trailing])
@@ -69,7 +69,7 @@ struct ServiceStatusView: View, HorizontalSizeClassOverride {
     
     private var dismissButton: some View {
         Button(action: dismiss) {
-            Text("Done").bold()
+            Text(LocalizedString("Done", comment: "Done button in service status view")).bold()
         }
     }
 }

--- a/NightscoutServiceKitUI/sv.lproj/Localizable.strings
+++ b/NightscoutServiceKitUI/sv.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-/* The title of the Nightscout API secret */
-"API Secret" = "API Secret";
+/* Dialog text before resetting secret key */
+"Are you sure you want to reset the secret key?" = "Är du säker på att du vill återställa den hemliga nyckeln?";
 
 /* Button text to cancel Nightscout credential input */
 "Cancel" = "Avbryt";
@@ -7,22 +7,16 @@
 /* Description of ServiceStatus of checking */
 "Checking..." = "Kontrollerar...";
 
-/* Button title to delete a service */
-"Delete Service" = "Ta bort tjänst";
-
-/* No comment provided by engineer. */
-"Done" = "Färdig";
-
-/* The placeholder text for the Nightscout site URL */
-"https://mysite.herokuapp.com" = "https://mysite.herokuapp.com";
+/* Done button in service status view */
+"Done" = "Klar";
 
 /* Button text to login on Nightscout CredentialsView */
 "Login" = "Logga in";
 
-/* No comment provided by engineer. */
+/* Logout button in service status view */
 "Logout" = "Logga ut";
 
-/* No comment provided by engineer. */
+/* Title of service status view */
 "Nightscout" = "Nightscout";
 
 /* Title on Nightscout CredentialsView */
@@ -34,15 +28,14 @@
 /* Description of ServiceStatus of checking */
 "OK" = "OK";
 
-/* The default placeholder for required text */
-"Required" = "Krävs";
+/* One-Time Password row header in service status view */
+"One-Time Password" = "Engångskod";
 
-/* The title of the Nightscout site URL */
-"Site URL" = "Nightscout-URL";
+/* Dialog title to reset secret key */
+"Reset Secret Key" = "Återställ hemlig nyckel";
 
-/* No comment provided by engineer. */
+/* Status row header in service status view */
 "Status" = "Status";
 
-/* No comment provided by engineer. */
+/* URL row header in service status view */
 "URL" = "URL";
-


### PR DESCRIPTION
I noticed that there were a lot of missing Swedish translations in general for the Loop app. This PR addresses this in the NightscoutService repository.

- Added missing Swedish translations in the respective `Localizable.strings` files.
- Added `LocalizedString` calls where needed, which will help with other translations as well.
- Removed outdated translations that are no longer needed.