### PR TITLE
Upload isCharging in uploader device status

### DIFF
--- a/NightscoutServiceKit/Extensions/StoredDosingDecision.swift
+++ b/NightscoutServiceKit/Extensions/StoredDosingDecision.swift
@@ -139,7 +139,10 @@ extension StoredDosingDecision {
     var uploaderStatus: UploaderStatus {
         let uploaderDevice = UIDevice.current
         let battery = uploaderDevice.isBatteryMonitoringEnabled ? Int(uploaderDevice.batteryLevel * 100) : 0
-        return UploaderStatus(name: uploaderDevice.name, timestamp: date, battery: battery)
+        let isCharging: Bool? = uploaderDevice.isBatteryMonitoringEnabled
+            ? (uploaderDevice.batteryState == .charging || uploaderDevice.batteryState == .full)
+            : nil
+        return UploaderStatus(name: uploaderDevice.name, timestamp: date, battery: battery, isCharging: isCharging)
     }
     
     func deviceStatus(automaticDoseDecision: StoredDosingDecision?) -> DeviceStatus {


### PR DESCRIPTION
Populates the `isCharging` flag on the `uploader` section of the Nightscout device status from the device's battery state, so consumers (e.g. LoopFollow) can show whether the uploading device is currently on power.

A full battery counts as charging, matching iOS battery state semantics: a plugged-in device at 100% reports `.full` rather than `.charging`. The flag is only set when battery monitoring is enabled; otherwise it is omitted. The key name `isCharging` matches the field already produced by Trio and consumed by LoopFollow.

Depends on LoopKit/NightscoutKit#2, which adds `isCharging` to `UploaderStatus`.