### PR TITLE
Upload bolus origin for user-initiated boluses

### DIFF
--- a/NightscoutServiceKit/Extensions/DoseEntry.swift
+++ b/NightscoutServiceKit/Extensions/DoseEntry.swift
@@ -18,6 +18,11 @@ extension DoseEntry {
         case .basal:
             return nil
         case .bolus:
+            // Non-automatic boluses may carry a finer origin (remote/watch/manual/shortcut), recorded by the
+            // app against the dose's syncIdentifier. Automatic boluses are already distinguished by `automatic`.
+            // `notes` carries the human-readable label so it shows in the Nightscout UI; `bolusOrigin` is the
+            // stable machine token.
+            let origin = syncIdentifier.flatMap { BolusOriginStore.shared.origin(forSyncIdentifier: $0) }
             return BolusNightscoutTreatment(
                 timestamp: startDate,
                 enteredBy: source,
@@ -27,9 +32,11 @@ extension DoseEntry {
                 unabsorbed: 0,  // The pump's reported IOB isn't relevant, nor stored
                 duration: duration,
                 automatic: automatic ?? false,
+                notes: origin?.displayName,
                 /* id: objectId, */ /// Specifying _id only works when doing a put (modify); all dose uploads are currently posting so they can be either create or update
                 syncIdentifier: syncIdentifier,
-                insulinType: insulinType?.brandName
+                insulinType: insulinType?.brandName,
+                bolusOrigin: origin?.rawValue
             )
         case .resume:
             return nil


### PR DESCRIPTION
Looks up the origin the app recorded for a user-initiated bolus (via LoopKit's `BolusOriginStore`, keyed by the dose's `syncIdentifier`) and uploads it as `bolusOrigin`, plus a readable note so it shows in the Nightscout UI. Automatic boluses are unaffected.

Depends on LoopKit/LoopKit#594 and LoopKit/NightscoutKit#3. The app side that records the origin is LoopKit/Loop#2455.